### PR TITLE
feat: pre-commit hooksとMakefileによる開発環境改善

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# .pre-commit-config.yaml
+repos:
+  # ruff - Python linting and formatting
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.9
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  # mypy - Static type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy
+        args: [src/]
+        additional_dependencies: [click, rich, json5]
+
+  # 基本的なファイルチェック
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: debug-statements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,24 +8,56 @@ DevContainer Toolsは、複雑なdevcontainer CLIを簡略化し、チーム開�
 
 ## 開発環境セットアップ
 
+### 初回セットアップ
+```bash
+# ワンコマンドでセットアップ
+make setup
+```
+
+### 従来のコマンド（必要に応じて）
 ```bash
 # 依存関係のインストール
 uv sync --dev
 uv pip install -e .[dev]
 
 # パッケージのローカルインストール（CLI利用のため）
-uv tool install .
+# 開発中は --editable を使用して変更を即座に反映
+uv tool install --editable .
 ```
 
 ## 開発用コマンド
 
+### 品質チェック
+```bash
+# 全品質チェック（CI環境と同じ）
+make check
+
+# 個別チェック
+make lint           # ruff linting
+make format         # black formatting
+make type-check     # mypy type checking
+make test           # pytest testing
+```
+
+### Pre-commit Hooks
+```bash
+# 自動実行（git commit時）
+git commit -m "your message"
+
+# 手動実行
+make pre-commit-run
+
+# 全ファイルでチェック
+uv run pre-commit run --all-files
+```
+
 ### テスト実行
 ```bash
-# 全テスト実行
-uv run pytest
+# 基本テスト実行
+make test
 
 # カバレッジ付きテスト
-uv run pytest --cov=devcontainer_tools
+make test-cov
 
 # 特定のテストファイル
 uv run pytest tests/test_config.py
@@ -34,7 +66,7 @@ uv run pytest tests/test_config.py
 uv run pytest tests/test_config.py::TestDeepMerge::test_simple_merge
 ```
 
-### コード品質チェック
+### 旧コマンド（直接実行）
 ```bash
 # Linting
 uv run ruff check .
@@ -55,7 +87,7 @@ uv build
 
 # 開発モードでの再インストール
 uv tool uninstall devcontainer-tools
-uv tool install .
+uv tool install --editable .
 ```
 
 ## アーキテクチャ
@@ -80,6 +112,7 @@ uv tool install .
 ### CLIコマンドの処理フロー
 
 - **up**: 設定マージ → 一時ファイル作成 → devcontainer CLIに委譲
+  - `--dry-run`オプションで設定確認のみ可能
 - **exec**: コンテナID検出 → docker exec優先、フォールバックでdevcontainer exec
 - **status**: コンテナID取得 → docker inspectで詳細情報表示
 
@@ -101,6 +134,9 @@ uv tool install .
 
 ### Rich Console出力
 全てのユーザー向け出力はrichライブラリを使用。色付き、テーブル表示対応。
+
+### JSONC（コメント付きJSON）サポート
+`devcontainer.json`のコメント（`//`）をサポートするため、`json5`ライブラリを使用してパースを実行。
 
 ## 日本語対応
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,86 @@
+# Makefile
+.PHONY: help setup install test lint format type-check clean check pre-commit-install pre-commit-run
+
+# デフォルトターゲット
+help:
+	@echo "利用可能なコマンド:"
+	@echo "  make setup          - 開発環境の初期セットアップ"
+	@echo "  make install        - 依存関係のインストール"
+	@echo "  make test           - テスト実行"
+	@echo "  make lint           - リント実行"
+	@echo "  make format         - コードフォーマット"
+	@echo "  make type-check     - 型チェック"
+	@echo "  make check          - CI環境と同じチェックを実行"
+	@echo "  make pre-commit-run - pre-commit手動実行"
+	@echo "  make clean          - キャッシュファイル削除"
+
+# 開発環境セットアップ（メインコマンド）
+setup: install pre-commit-install
+	@echo "✅ 開発環境のセットアップが完了しました"
+	@echo "📝 git commit時に自動的にpre-commitが実行されます"
+
+# 依存関係インストール
+install:
+	@echo "📦 依存関係をインストール中..."
+	uv sync --dev
+	uv pip install -e .[dev]
+
+# Pre-commit hooks インストール
+pre-commit-install:
+	@echo "🔧 Pre-commit hooksをインストール中..."
+	uv run pre-commit install
+	@echo "🧪 全ファイルでpre-commitテスト実行中..."
+	uv run pre-commit run --all-files || true
+
+# テスト実行
+test:
+	@echo "🧪 テスト実行中..."
+	uv run pytest
+
+# テスト（カバレッジ付き）
+test-cov:
+	@echo "🧪 カバレッジ付きテスト実行中..."
+	uv run pytest --cov=devcontainer_tools --cov-report=term --cov-report=html
+
+# リント実行
+lint:
+	@echo "🔍 リント実行中..."
+	uv run ruff check .
+
+# リント修正
+lint-fix:
+	@echo "🔧 リント自動修正中..."
+	uv run ruff check --fix .
+
+# フォーマット確認
+format-check:
+	@echo "📏 フォーマット確認中..."
+	uv run black --check .
+
+# フォーマット実行
+format:
+	@echo "📏 フォーマット実行中..."
+	uv run black .
+
+# 型チェック
+type-check:
+	@echo "🔍 型チェック実行中..."
+	uv run mypy src/
+
+# CI環境と同じチェック
+check: lint format-check type-check test
+	@echo "✅ すべてのチェックが完了しました"
+
+# Pre-commit手動実行
+pre-commit-run:
+	@echo "🔧 Pre-commit手動実行中..."
+	uv run pre-commit run --all-files
+
+# キャッシュクリア
+clean:
+	@echo "🗑️  キャッシュファイル削除中..."
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".mypy_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".ruff_cache" -exec rm -rf {} + 2>/dev/null || true
+	rm -rf htmlcov/ coverage.xml .coverage 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@
 
 ## 📦 インストール
 
+### 前提条件
+
+devcontainer CLIが必要です。インストールされていない場合は以下を実行してください：
+
+```bash
+npm install -g @devcontainers/cli
+```
+
 ### uvツールとしてインストール（推奨）
 
 ```bash
 # GitHubから直接インストール
-uv tool install --from git+https://github.com/your-team/devcontainer-tools --name dev
+uv tool install --from git+https://github.com/Mayu-mic/devcontainer-tools --name dev
 
 # ローカルディレクトリからインストール
 cd devcontainer-scripts
@@ -27,9 +35,27 @@ uv tool install --from . --name dev
 ### 開発者向けインストール
 
 ```bash
-git clone https://github.com/your-team/devcontainer-tools
+git clone https://github.com/Mayu-mic/devcontainer-tools
 cd devcontainer-tools
-uv pip install -e .[dev]
+
+# ワンコマンドでセットアップ
+make setup
+```
+
+### 開発用コマンド
+
+```bash
+# 全品質チェック実行
+make check
+
+# 個別コマンド
+make test           # テスト実行
+make lint           # リント実行
+make format         # フォーマット
+make type-check     # 型チェック
+
+# Pre-commit手動実行
+make pre-commit-run
 ```
 
 ## 🚀 使い方
@@ -63,6 +89,9 @@ dev up --env NODE_ENV=development --env DEBUG=true
 
 # デバッグモードで設定内容を確認
 dev up --debug
+
+# 設定をマージして確認のみ（実際の起動は行わない）
+dev up --dry-run
 ```
 
 ### コンテナ操作
@@ -177,11 +206,16 @@ dev up --mount /host/path:/container/path
 - Docker
 - devcontainer CLI
 
+devcontainer CLIのインストール:
+```bash
+npm install -g @devcontainers/cli
+```
+
 ### 開発セットアップ
 
 ```bash
 # リポジトリをクローン
-git clone https://github.com/your-team/devcontainer-tools
+git clone https://github.com/Mayu-mic/devcontainer-tools
 cd devcontainer-tools
 
 # 開発依存関係をインストール
@@ -231,6 +265,7 @@ dev up [OPTIONS]
 - `--workspace PATH`: ワークスペースフォルダ（デフォルト: カレントディレクトリ）
 - `--common-config PATH`: 共通設定ファイル（デフォルト: devcontainer.common.json）
 - `--debug`: デバッグ情報を表示
+- `--dry-run`: 設定をマージして表示のみ（実際の起動は行わない）
 
 ### `dev exec`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/your-team/devcontainer-tools"
-Documentation = "https://github.com/your-team/devcontainer-tools#readme"
-Repository = "https://github.com/your-team/devcontainer-tools.git"
-Issues = "https://github.com/your-team/devcontainer-tools/issues"
+Homepage = "https://github.com/Mayu-mic/devcontainer-tools"
+Documentation = "https://github.com/Mayu-mic/devcontainer-tools#readme"
+Repository = "https://github.com/Mayu-mic/devcontainer-tools.git"
+Issues = "https://github.com/Mayu-mic/devcontainer-tools/issues"
 
 [project.scripts]
 dev = "devcontainer_tools.cli:cli"
@@ -44,6 +44,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "black>=23.0.0",
+    "pre-commit>=3.0.0",
 ]
 
 [build-system]
@@ -56,6 +57,8 @@ packages = ["src/devcontainer_tools"]
 [tool.ruff]
 line-length = 100
 target-version = "py38"
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -69,7 +72,7 @@ ignore = [
     "E501",  # line too long (handled by black)
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]  # allow asserts in tests
 
 [tool.black]

--- a/src/devcontainer_tools/cli.py
+++ b/src/devcontainer_tools/cli.py
@@ -32,7 +32,7 @@ console = Console()
 def cli():
     """
     DevContainer簡略化管理ツール
-    
+
     複雑なdevcontainer CLIオプションを簡略化し、
     設定ファイルの自動マージ機能を提供します。
     """
@@ -40,19 +40,32 @@ def cli():
 
 
 @cli.command()
-@click.option('--clean', is_flag=True, help='既存のコンテナを削除してから起動')
-@click.option('--no-cache', is_flag=True, help='キャッシュを使用せずにビルド')
-@click.option('--gpu', is_flag=True, help='GPU サポートを有効化')
-@click.option('--mount', multiple=True, help='追加マウント (形式: source:target または完全なマウント文字列)')
-@click.option('--env', multiple=True, help='追加環境変数 (形式: NAME=VALUE)')
-@click.option('--port', multiple=True, help='追加ポートフォワード (形式: PORT または PORT:PORT)')
-@click.option('--workspace', type=click.Path(exists=True, path_type=Path), default=Path.cwd(), help='ワークスペースフォルダ')
-@click.option('--common-config', type=click.Path(path_type=Path), default=Path.home() / '.config' / 'devcontainer.common.json', help='共通設定ファイル')
-@click.option('--debug', is_flag=True, help='デバッグ情報を表示')
-def up(clean, no_cache, gpu, mount, env, port, workspace, common_config, debug):
+@click.option("--clean", is_flag=True, help="既存のコンテナを削除してから起動")
+@click.option("--no-cache", is_flag=True, help="キャッシュを使用せずにビルド")
+@click.option("--gpu", is_flag=True, help="GPU サポートを有効化")
+@click.option(
+    "--mount", multiple=True, help="追加マウント (形式: source:target または完全なマウント文字列)"
+)
+@click.option("--env", multiple=True, help="追加環境変数 (形式: NAME=VALUE)")
+@click.option("--port", multiple=True, help="追加ポートフォワード (形式: PORT または PORT:PORT)")
+@click.option(
+    "--workspace",
+    type=click.Path(exists=True, path_type=Path),
+    default=Path.cwd(),
+    help="ワークスペースフォルダ",
+)
+@click.option(
+    "--common-config",
+    type=click.Path(path_type=Path),
+    default=Path.home() / ".config" / "devcontainer.common.json",
+    help="共通設定ファイル",
+)
+@click.option("--debug", is_flag=True, help="デバッグ情報を表示")
+@click.option("--dry-run", is_flag=True, help="設定をマージして表示のみ（実際の起動は行わない）")
+def up(clean, no_cache, gpu, mount, env, port, workspace, common_config, debug, dry_run):
     """
     開発コンテナを起動または作成する。
-    
+
     共通設定とプロジェクト設定を自動的にマージし、
     forwardPortsからappPortへの変換も行います。
     """
@@ -66,18 +79,45 @@ def up(clean, no_cache, gpu, mount, env, port, workspace, common_config, debug):
     # 環境変数をパース（NAME=VALUE形式）
     env_pairs: List[Tuple[str, str]] = []
     for env_var in env:
-        if '=' in env_var:
-            key, value = env_var.split('=', 1)
+        if "=" in env_var:
+            key, value = env_var.split("=", 1)
             env_pairs.append((key, value))
 
     # すべての設定をマージ
     merged_config = merge_configurations(
-        common_config,
-        project_config,
-        list(mount),
-        env_pairs,
-        list(port)
+        common_config, project_config, list(mount), env_pairs, list(port)
     )
+
+    # dry-runモードの場合は設定表示のみ
+    if dry_run:
+        console.print("\n[bold blue]🔍 Dry Run Mode - 設定確認のみ[/bold blue]")
+
+        # 設定ファイルの情報を表示
+        console.print("\n[bold]設定ソース:[/bold]")
+        if project_config:
+            console.print(f"📄 プロジェクト設定: {project_config.relative_to(workspace)}")
+        else:
+            console.print("📄 プロジェクト設定: [yellow]見つかりません[/yellow]")
+
+        if common_config.exists():
+            console.print(f"🌐 共通設定: {common_config}")
+        else:
+            console.print("🌐 共通設定: [yellow]見つかりません[/yellow]")
+
+        if mount or env or port:
+            console.print("⚙️  コマンドラインオプション:")
+            if mount:
+                console.print(f"   マウント: {list(mount)}")
+            if env:
+                console.print(f"   環境変数: {list(env)}")
+            if port:
+                console.print(f"   ポート: {list(port)}")
+
+        console.print(
+            Panel(JSON(json.dumps(merged_config, indent=2)), title="マージ後の devcontainer.json")
+        )
+        console.print("\n[green]✅ 設定の確認が完了しました。実際の起動は行いません。[/green]")
+        return
 
     # デバッグモードの場合、マージされた設定を表示
     if debug:
@@ -85,16 +125,19 @@ def up(clean, no_cache, gpu, mount, env, port, workspace, common_config, debug):
         console.print(Panel(JSON(json.dumps(merged_config, indent=2)), title="devcontainer.json"))
 
     # 一時的な設定ファイルを作成
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(merged_config, f, indent=2)
         temp_config_path = f.name
 
     try:
         # devcontainerコマンドを構築
         cmd = [
-            "devcontainer", "up",
-            "--workspace-folder", str(workspace),
-            "--override-config", temp_config_path  # マージされた設定を使用
+            "devcontainer",
+            "up",
+            "--workspace-folder",
+            str(workspace),
+            "--override-config",
+            temp_config_path,  # マージされた設定を使用
         ]
 
         # オプションフラグを追加
@@ -122,13 +165,18 @@ def up(clean, no_cache, gpu, mount, env, port, workspace, common_config, debug):
 
 
 @cli.command()
-@click.argument('command', nargs=-1, required=True)
-@click.option('--workspace', type=click.Path(exists=True, path_type=Path), default=Path.cwd(), help='ワークスペースフォルダ')
-@click.option('--no-up', is_flag=True, help='コンテナが起動していない場合でも自動起動しない')
+@click.argument("command", nargs=-1, required=True)
+@click.option(
+    "--workspace",
+    type=click.Path(exists=True, path_type=Path),
+    default=Path.cwd(),
+    help="ワークスペースフォルダ",
+)
+@click.option("--no-up", is_flag=True, help="コンテナが起動していない場合でも自動起動しない")
 def exec(command, workspace, no_up):
     """
     実行中のコンテナ内でコマンドを実行する。
-    
+
     可能な場合はdocker execを直接使用してパフォーマンスを向上させる。
     コンテナが見つからない場合、デフォルトで自動的にコンテナを起動する。
     --no-upオプションを指定すると従来通りエラーで停止する。
@@ -138,12 +186,17 @@ def exec(command, workspace, no_up):
 
 
 @cli.command()
-@click.option('--workspace', type=click.Path(exists=True, path_type=Path), default=Path.cwd(), help='ワークスペースフォルダ')
+@click.option(
+    "--workspace",
+    type=click.Path(exists=True, path_type=Path),
+    default=Path.cwd(),
+    help="ワークスペースフォルダ",
+)
 @click.pass_context
 def rebuild(ctx, workspace):
     """
     コンテナを最初から再ビルドする。
-    
+
     既存のコンテナを削除し、キャッシュを使用せずに
     新しいコンテナをビルドします。
     """
@@ -153,11 +206,16 @@ def rebuild(ctx, workspace):
 
 
 @cli.command()
-@click.option('--workspace', type=click.Path(exists=True, path_type=Path), default=Path.cwd(), help='ワークスペースフォルダ')
+@click.option(
+    "--workspace",
+    type=click.Path(exists=True, path_type=Path),
+    default=Path.cwd(),
+    help="ワークスペースフォルダ",
+)
 def status(workspace):
     """
     コンテナのステータスと設定を表示する。
-    
+
     実行中のコンテナの情報、マウント状況、
     使用中の設定ファイルなどを表示します。
     """
@@ -187,7 +245,9 @@ def status(workspace):
             if mounts:
                 mount_list = []
                 for mount in mounts[:3]:
-                    mount_list.append(f"• {mount.get('Source', 'Unknown')} → {mount.get('Destination', 'Unknown')}")
+                    mount_list.append(
+                        f"• {mount.get('Source', 'Unknown')} → {mount.get('Destination', 'Unknown')}"
+                    )
                 if len(mounts) > 3:
                     mount_list.append(f"• ... and {len(mounts) - 3} more")
                 table.add_row("Mounts", "\n".join(mount_list))
@@ -205,11 +265,16 @@ def status(workspace):
 
 
 @cli.command()
-@click.option('--common-config', type=click.Path(path_type=Path), default=Path.home() / '.config' / 'devcontainer.common.json', help='作成する共通設定ファイル')
+@click.option(
+    "--common-config",
+    type=click.Path(path_type=Path),
+    default=Path.home() / ".config" / "devcontainer.common.json",
+    help="作成する共通設定ファイル",
+)
 def init(common_config):
     """
     共通設定テンプレートを初期化する。
-    
+
     devcontainer.common.jsonファイルを作成し、
     よく使用される基本的な設定を含めます。
     """
@@ -232,5 +297,5 @@ def init(common_config):
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()


### PR DESCRIPTION
## 概要
CI失敗の事前検知とワンコマンドセットアップを実現するpre-commit hooksとMakefileを導入しました。

## 新機能

### 🔧 Makefile
開発用コマンドを統一し、ワンコマンドでのセットアップを実現：

- `make setup`: 開発環境の初期セットアップ（依存関係 + pre-commit hooks）
- `make check`: CI環境と同じ品質チェックをローカルで実行
- `make test/lint/format/type-check`: 個別品質チェックコマンド
- `make pre-commit-run`: pre-commit手動実行
- `make clean`: キャッシュファイル削除

### 🎯 pre-commit hooks
コミット時の自動品質チェック：

- **ruff**: linting + code formatting
- **mypy**: 静的型チェック（click, rich, json5依存関係対応）
- **basic checks**: trailing-whitespace, end-of-file-fixer, yaml/toml/json validation

## 設定更新

### pyproject.toml
- pre-commit>=3.0.0 依存関係を追加
- ruff設定を新しい構造に更新（`tool.ruff.lint.*`）

### ドキュメント
- **CLAUDE.md**: `make setup`による初回セットアップ手順を追加
- **README.md**: 開発者向けインストール手順を簡略化

## 期待される効果

✅ **CI失敗の事前検知**: `make check`でローカルでCI環境と同じチェックを実行  
✅ **新規開発者のオンボーディング簡素化**: `make setup`だけで環境構築完了  
✅ **コード品質の自動保証**: コミット時に自動的に品質チェック実行  
✅ **開発効率向上**: 統一されたインターフェースで一貫した開発体験  

## テスト計画

- [x] `make setup`で正常にpre-commit hookがインストールされる
- [x] `make check`で全ての品質チェックが正常に動作する
- [x] git commit時にpre-commit hooksが自動実行される
- [x] pre-commit hooksが適切にコードを自動修正する

## 利用方法

### 新規開発者
```bash
git clone <repo>
cd devcontainer-tools
make setup  # これだけで環境構築完了
```

### PR作成前の品質チェック
```bash
make check  # CI環境と同じチェックを実行
```

### 日常の開発フロー
```bash
# コード編集
git add .
git commit -m "fix: something"  # 自動的にpre-commit実行
```

🤖 Generated with [Claude Code](https://claude.ai/code)