### PR TITLE
feat: devcontainer.jsonが存在しない場合にupコマンドを失敗させる機能を追加

### DIFF
--- a/src/devcontainer_tools/cli.py
+++ b/src/devcontainer_tools/cli.py
@@ -84,7 +84,13 @@ def up(
     # プロジェクト設定を検索
     project_config = find_devcontainer_json(workspace)
     if not project_config:
-        console.print("[yellow]No devcontainer.json found in workspace[/yellow]")
+        console.print("[bold red]✗ devcontainer.json が見つかりません[/bold red]")
+        console.print(
+            "[yellow]ワークスペースには以下のいずれかが必要です:[/yellow]\n"
+            "  • .devcontainer/devcontainer.json\n"
+            "  • devcontainer.json"
+        )
+        sys.exit(1)
 
     # 環境変数をパース（NAME=VALUE形式）
     env_pairs: list[tuple[str, str]] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,19 +84,19 @@ class TestCliUp:
     """Test the up command."""
 
     @patch("subprocess.run")
-    @patch("devcontainer_tools.utils.find_devcontainer_json")
-    def test_up_basic(self, mock_find_config, mock_subprocess):
+    def test_up_basic(self, mock_subprocess):
         """Test basic up command."""
         runner = CliRunner()
-
-        # Mock finding no project config
-        mock_find_config.return_value = None
 
         # Mock successful subprocess run
         mock_subprocess.return_value = MagicMock(returncode=0)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             workspace = Path(temp_dir)
+            # Create devcontainer.json
+            devcontainer_path = workspace / ".devcontainer" / "devcontainer.json"
+            devcontainer_path.parent.mkdir(parents=True, exist_ok=True)
+            devcontainer_path.write_text('{"name": "test"}')
 
             result = runner.invoke(cli, ["up", "--workspace", str(workspace)])
 
@@ -107,16 +107,18 @@ class TestCliUp:
             assert args[0:2] == ["devcontainer", "up"]
 
     @patch("subprocess.run")
-    @patch("devcontainer_tools.utils.find_devcontainer_json")
-    def test_up_with_options(self, mock_find_config, mock_subprocess):
+    def test_up_with_options(self, mock_subprocess):
         """Test up command with various options."""
         runner = CliRunner()
 
-        mock_find_config.return_value = None
         mock_subprocess.return_value = MagicMock(returncode=0)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             workspace = Path(temp_dir)
+            # Create devcontainer.json
+            devcontainer_path = workspace / ".devcontainer" / "devcontainer.json"
+            devcontainer_path.parent.mkdir(parents=True, exist_ok=True)
+            devcontainer_path.write_text('{"name": "test"}')
 
             result = runner.invoke(
                 cli,
@@ -155,10 +157,56 @@ class TestCliUp:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             workspace = Path(temp_dir)
+            # Create devcontainer.json
+            devcontainer_path = workspace / ".devcontainer" / "devcontainer.json"
+            devcontainer_path.parent.mkdir(parents=True, exist_ok=True)
+            devcontainer_path.write_text('{"name": "test"}')
 
             result = runner.invoke(cli, ["up", "--workspace", str(workspace)])
 
             assert result.exit_code == 1
+
+    def test_up_no_devcontainer_json(self):
+        """Test up command fails when no devcontainer.json exists."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+
+            result = runner.invoke(cli, ["up", "--workspace", str(workspace)])
+
+            assert result.exit_code == 1
+            assert "devcontainer.json が見つかりません" in result.output
+
+    @patch("subprocess.run")
+    def test_up_with_devcontainer_json(self, mock_subprocess):
+        """Test up command succeeds when devcontainer.json exists."""
+        runner = CliRunner()
+        mock_subprocess.return_value = MagicMock(returncode=0)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            # Create devcontainer.json
+            devcontainer_path = workspace / ".devcontainer" / "devcontainer.json"
+            devcontainer_path.parent.mkdir(parents=True, exist_ok=True)
+            devcontainer_path.write_text('{"name": "test"}')
+
+            result = runner.invoke(cli, ["up", "--workspace", str(workspace)])
+
+            assert result.exit_code == 0
+            mock_subprocess.assert_called_once()
+
+    def test_up_dry_run_no_devcontainer_json(self):
+        """Test up command with --dry-run fails when no devcontainer.json exists."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+
+            result = runner.invoke(cli, ["up", "--workspace", str(workspace), "--dry-run"])
+
+            assert result.exit_code == 1
+            assert "devcontainer.json が見つかりません" in result.output
 
 
 class TestCliExec:
@@ -295,16 +343,18 @@ class TestCliRebuild:
     """Test the rebuild command."""
 
     @patch("subprocess.run")
-    @patch("devcontainer_tools.utils.find_devcontainer_json")
-    def test_rebuild(self, mock_find_config, mock_subprocess):
+    def test_rebuild(self, mock_subprocess):
         """Test rebuild command."""
         runner = CliRunner()
 
-        mock_find_config.return_value = None
         mock_subprocess.return_value = MagicMock(returncode=0)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             workspace = Path(temp_dir)
+            # Create devcontainer.json
+            devcontainer_path = workspace / ".devcontainer" / "devcontainer.json"
+            devcontainer_path.parent.mkdir(parents=True, exist_ok=True)
+            devcontainer_path.write_text('{"name": "test"}')
 
             result = runner.invoke(cli, ["rebuild", "--workspace", str(workspace)])
 


### PR DESCRIPTION
## Summary
- `devcontainer.json`が存在しない場合、`up`コマンドが即座に失敗するように変更
- 適切なエラーメッセージ（日本語）を表示してユーザーに必要なファイルの場所を案内
- TDDアプローチで実装し、包括的なテストカバレッジを確保

## Changes
- **CLI (`cli.py`)**: devcontainer.jsonの存在チェックを追加し、ファイルが見つからない場合は`sys.exit(1)`で終了
- **Tests (`test_cli.py`)**: 既存テストを更新し、新しいテストケースを追加
  - `test_up_no_devcontainer_json`: 設定ファイルなしでコマンドが失敗することを確認
  - `test_up_with_devcontainer_json`: 設定ファイルありでコマンドが成功することを確認
  - `test_up_dry_run_no_devcontainer_json`: dry-runモードでも同様に失敗することを確認

## Test plan
- [x] `make test`でテストが通ることを確認
- [x] `make check`ですべての品質チェックが通ることを確認
- [x] devcontainer.jsonが存在しない場合にエラーメッセージが表示されることを確認
- [x] devcontainer.jsonが存在する場合に正常に動作することを確認

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)