### PR TITLE
feat: forwardPortsのappPort自動変換をオプション化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,40 @@ uv tool uninstall devcontainer-tools
 uv tool install --editable .
 ```
 
+## 使用例
+
+### 基本的な使用方法
+```bash
+# 通常の起動（forwardPortsは変換されない）
+dev up
+
+# 設定確認のみ
+dev up --dry-run
+
+# forwardPortsをappPortに自動変換して起動
+dev up --auto-forward-ports
+
+# 追加オプションと組み合わせ
+dev up --auto-forward-ports --mount /host:/container --env NODE_ENV=development
+```
+
+### forwardPorts自動変換について
+
+**デフォルト動作（推奨）:**
+```bash
+dev up  # forwardPortsはそのまま保持、appPortには変換されない
+```
+
+**従来の動作（必要時のみ）:**
+```bash
+dev up --auto-forward-ports  # forwardPortsがappPortに変換される
+```
+
+この変更により：
+- VS Code拡張機能は`forwardPorts`を正常に認識
+- devcontainer CLIは`appPort`を使用（`--auto-forward-ports`指定時のみ）
+- 設定の重複や競合を回避
+
 ## アーキテクチャ
 
 ### モジュール構成
@@ -104,7 +138,7 @@ uv tool install --editable .
 
 1. `devcontainer.common.json`（チーム共通設定）を読み込み
 2. `.devcontainer/devcontainer.json`（プロジェクト設定）を読み込み
-3. `forwardPorts` → `appPort` 自動変換を実行
+3. `--auto-forward-ports`オプション指定時のみ`forwardPorts` → `appPort` 自動変換を実行
 4. コマンドライン引数（--mount, --env, --port）を追加
 5. 一時ファイルとして保存し、`devcontainer up --override-config`で使用
 
@@ -112,6 +146,7 @@ uv tool install --editable .
 
 - **up**: 設定マージ → 一時ファイル作成 → devcontainer CLIに委譲
   - `--dry-run`オプションで設定確認のみ可能
+  - `--auto-forward-ports`オプションで`forwardPorts`から`appPort`への自動変換を有効化
 - **exec**: コンテナID検出 → docker exec優先、フォールバックでdevcontainer exec
 - **status**: コンテナID取得 → docker inspectで詳細情報表示
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - 🚀 **簡略化されたコマンド**: 複雑なdevcontainer CLIオプションを直感的なインターフェースに
 - 🔄 **自動設定マージ**: 共通設定とプロジェクト設定を自動的に統合
-- 🎯 **forwardPorts変換**: VS CodeのforwardPortsを自動的にappPortに変換
+- 🎯 **forwardPorts変換**: オプション指定でVS CodeのforwardPortsをappPortに変換
 - 👥 **チーム対応**: 共通設定を共有して一貫した開発環境を提供
 - 💻 **高速実行**: 可能な場合はdocker execを直接使用してパフォーマンス向上
 - 🎨 **リッチな出力**: カラフルで読みやすいコンソール出力
@@ -92,6 +92,9 @@ dev up --debug
 
 # 設定をマージして確認のみ（実際の起動は行わない）
 dev up --dry-run
+
+# forwardPortsをappPortに自動変換して起動
+dev up --auto-forward-ports
 ```
 
 ### コンテナ操作
@@ -168,22 +171,36 @@ your-project/
 
 ## 🔄 自動変換機能
 
-### forwardPorts → appPort
+### forwardPorts → appPort（オプション）
 
-プロジェクト設定で `forwardPorts` を指定すると、自動的に `appPort` として扱われます：
+`--auto-forward-ports` オプションを指定した場合のみ、プロジェクト設定の `forwardPorts` が `appPort` に変換されます：
+
+```bash
+# デフォルト動作（推奨）- forwardPortsはそのまま保持
+dev up
+```
 
 ```json
-// 入力
+// 結果: forwardPortsはそのまま保持
 {
   "forwardPorts": [8000, 3000]
 }
+```
 
-// 自動変換後
+```bash
+# 従来の動作 - forwardPortsをappPortに変換
+dev up --auto-forward-ports
+```
+
+```json
+// 結果: forwardPortsはそのまま残り、appPortが追加される
 {
   "forwardPorts": [8000, 3000],
   "appPort": [8000, 3000]
 }
 ```
+
+この変更により、VS Code拡張機能との互換性が向上し、設定の重複や競合を回避できます。
 
 ### マウント形式の変換
 
@@ -269,6 +286,7 @@ dev up [OPTIONS]
 - `--common-config PATH`: 共通設定ファイル（デフォルト: devcontainer.common.json）
 - `--debug`: デバッグ情報を表示
 - `--dry-run`: 設定をマージして表示のみ（実際の起動は行わない）
+- `--auto-forward-ports`: forwardPortsをappPortに自動変換する
 
 ### `dev exec`
 

--- a/src/devcontainer_tools/cli.py
+++ b/src/devcontainer_tools/cli.py
@@ -66,6 +66,7 @@ def cli() -> None:
 )
 @click.option("--debug", is_flag=True, help="デバッグ情報を表示")
 @click.option("--dry-run", is_flag=True, help="設定をマージして表示のみ（実際の起動は行わない）")
+@click.option("--auto-forward-ports", is_flag=True, help="forwardPortsをappPortに自動変換する")
 def up(
     clean: bool,
     no_cache: bool,
@@ -77,11 +78,13 @@ def up(
     common_config: Path,
     debug: bool,
     dry_run: bool,
+    auto_forward_ports: bool,
 ) -> None:
     """
     開発コンテナを起動または作成する。
 
-    共通設定とプロジェクト設定を自動的にマージし、
+    共通設定とプロジェクト設定を自動的にマージします。
+    --auto-forward-portsオプションを指定すると、
     forwardPortsからappPortへの変換も行います。
     """
     console.print("[bold green]Starting devcontainer...[/bold green]")
@@ -106,7 +109,7 @@ def up(
 
     # すべての設定をマージ
     merged_config = merge_configurations(
-        common_config, project_config, list(mount), env_pairs, list(port)
+        common_config, project_config, list(mount), env_pairs, list(port), auto_forward_ports
     )
 
     # dry-runモードの場合は設定表示のみ

--- a/src/devcontainer_tools/config.py
+++ b/src/devcontainer_tools/config.py
@@ -70,6 +70,7 @@ def merge_configurations(
     additional_mounts: list[str],
     additional_env: list[tuple[str, str]],
     additional_ports: list[str],
+    auto_forward_ports: bool = False,
 ) -> dict[str, Any]:
     """
     すべての設定をマージする。
@@ -84,14 +85,14 @@ def merge_configurations(
 
     ポート設定の処理:
     - forwardPorts: VS Code用設定（読み取り専用として保持）
-    - appPort: devcontainer CLI用設定（forwardPorts + 追加ポート）
+    - appPort: devcontainer CLI用設定（auto_forward_ports=Trueの場合のみforwardPorts + 追加ポート）
 
     Note: devcontainer CLIはforwardPortsを認識しないため、
-          appPortに変換して追加ポートと組み合わせる。
+          auto_forward_ports=Trueの場合にappPortに変換して追加ポートと組み合わせる。
           forwardPortsは元の値のまま保持され、VS Code連携用に残される。
 
     特殊な処理:
-    - forwardPortsをappPortに自動変換
+    - auto_forward_ports=Trueの場合のみ、forwardPortsをappPortに自動変換
     - マウント、環境変数、ポートの追加
 
     Args:
@@ -100,6 +101,7 @@ def merge_configurations(
         additional_mounts: 追加マウントのリスト
         additional_env: 追加環境変数のリスト（タプル）
         additional_ports: 追加ポートのリスト
+        auto_forward_ports: forwardPortsをappPortに自動変換するかどうか（デフォルト: False）
 
     Returns:
         マージされた設定辞書
@@ -108,10 +110,10 @@ def merge_configurations(
     if project_config_path and project_config_path.exists():
         project_config = load_json_file(project_config_path)
 
-        # forwardPorts -> appPort の自動変換
+        # forwardPorts -> appPort の自動変換（オプション指定時のみ）
         # devcontainer CLIはforwardPortsを認識しないため、appPortに変換
         # forwardPortsは読み取り専用として保持し、VS Code連携用に残す
-        if "forwardPorts" in project_config:
+        if auto_forward_ports and "forwardPorts" in project_config:
             project_config["appPort"] = project_config["forwardPorts"].copy()
 
         merged = project_config.copy()


### PR DESCRIPTION
## Summary

- forwardPortsからappPortへの自動変換をデフォルトで無効化
- `--auto-forward-ports`オプション指定時のみ実行するように変更
- Issueで要求された機能を実装

## Changes

- **cli.py**: `--auto-forward-ports`オプションを追加
- **config.py**: `merge_configurations`関数に`auto_forward_ports`パラメータを追加し、オプション指定時のみ自動変換を実行
- **tests**: 新機能に対応したテストケースを追加・更新

## Breaking Changes

⚠️ **破壊的変更**: デフォルトで`forwardPorts`が`appPort`に変換されなくなります。

従来の動作が必要な場合は`--auto-forward-ports`オプションを指定してください：

```bash
# 新しい動作（デフォルト）
dev up  # forwardPortsは変換されない

# 従来の動作
dev up --auto-forward-ports  # forwardPortsがappPortに変換される
```

## Test plan

- [x] 既存のテストが全て通ることを確認
- [x] `--auto-forward-ports`オプション指定時に自動変換が動作することをテストで確認
- [x] デフォルトで自動変換が無効になっていることをテストで確認
- [x] LintとMypyのチェックが通ることを確認

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)