### PR TITLE
improve: Dockerエラーハンドリングとデバッグ機能を強化

### DIFF
--- a/src/devcontainer_tools/container.py
+++ b/src/devcontainer_tools/container.py
@@ -17,7 +17,11 @@ console = Console()
 
 
 def run_command(
-    cmd: list[str], check: bool = True, capture_output: bool = True, text: bool = True
+    cmd: list[str],
+    check: bool = True,
+    capture_output: bool = True,
+    text: bool = True,
+    verbose: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """
     コマンドを実行し、結果を返す。
@@ -27,12 +31,26 @@ def run_command(
         check: エラー時に例外を発生させるかどうか
         capture_output: 出力をキャプチャするかどうか
         text: テキストモードで実行するかどうか
+        verbose: 詳細なデバッグ情報を表示するかどうか
 
     Returns:
         コマンドの実行結果
     """
-    console.print(f"[cyan]Executing:[/cyan] {' '.join(cmd)}")
-    return subprocess.run(cmd, check=check, capture_output=capture_output, text=text)
+    console.print(f"[cyan]実行中:[/cyan] {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=check, capture_output=capture_output, text=text)
+
+    if verbose:
+        console.print(f"[dim]デバッグ情報: returncode={result.returncode}[/dim]")
+        if result.stdout:
+            console.print(
+                f"[dim]stdout: {result.stdout[:200]}{'...' if len(result.stdout) > 200 else ''}[/dim]"
+            )
+        if result.stderr:
+            console.print(
+                f"[dim]stderr: {result.stderr[:200]}{'...' if len(result.stderr) > 200 else ''}[/dim]"
+            )
+
+    return result
 
 
 def get_container_id(workspace: Path) -> str | None:
@@ -126,13 +144,22 @@ def ensure_container_running(workspace: Path) -> bool:
     try:
         # devcontainer upを実行
         cmd = ["devcontainer", "up", "--workspace-folder", str(workspace)]
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = run_command(cmd, check=False, verbose=True)
 
         if result.returncode == 0:
             console.print("[bold green]✓ コンテナの自動起動が完了しました[/bold green]")
             return True
         else:
-            console.print(f"[bold red]✗ コンテナの起動に失敗しました: {result.stderr}[/bold red]")
+            # エラーメッセージの詳細な処理
+            error_msg = ""
+            if result.stderr:
+                error_msg = result.stderr.strip()
+            elif result.stdout:
+                error_msg = result.stdout.strip()
+            else:
+                error_msg = f"プロセス終了コード: {result.returncode}"
+
+            console.print(f"[bold red]✗ コンテナの起動に失敗しました: {error_msg}[/bold red]")
             return False
     except Exception as e:
         console.print(f"[bold red]✗ コンテナの起動中にエラーが発生しました: {e}[/bold red]")
@@ -153,10 +180,15 @@ def stop_and_remove_container(container_id: str, remove_volumes: bool = False) -
     try:
         # コンテナを停止
         console.print(f"[yellow]コンテナを停止しています... (ID: {container_id[:12]})[/yellow]")
-        result = run_command(["docker", "stop", container_id], check=False)
+        result = run_command(["docker", "stop", container_id], check=False, verbose=True)
 
         if result.returncode != 0:
-            console.print(f"[red]コンテナの停止に失敗しました: {result.stderr}[/red]")
+            error_msg = (
+                result.stderr.strip()
+                if result.stderr
+                else f"プロセス終了コード: {result.returncode}"
+            )
+            console.print(f"[red]コンテナの停止に失敗しました: {error_msg}[/red]")
             return False
 
         # コンテナを削除
@@ -165,10 +197,15 @@ def stop_and_remove_container(container_id: str, remove_volumes: bool = False) -
         if remove_volumes:
             cmd.append("-v")  # ボリュームも削除
 
-        result = run_command(cmd, check=False)
+        result = run_command(cmd, check=False, verbose=True)
 
         if result.returncode != 0:
-            console.print(f"[red]コンテナの削除に失敗しました: {result.stderr}[/red]")
+            error_msg = (
+                result.stderr.strip()
+                if result.stderr
+                else f"プロセス終了コード: {result.returncode}"
+            )
+            console.print(f"[red]コンテナの削除に失敗しました: {error_msg}[/red]")
             return False
 
         console.print("[green]✓ コンテナの停止・削除が完了しました[/green]")

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -5,7 +5,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from devcontainer_tools.container import execute_in_container
+from devcontainer_tools.container import (
+    ensure_container_running,
+    execute_in_container,
+    run_command,
+)
 
 
 class TestExecuteInContainer:
@@ -100,3 +104,173 @@ class TestExecuteInContainer:
             text=True,
         )
         assert result.returncode == 0
+
+
+class TestRunCommand:
+    """run_command関数のテスト"""
+
+    @patch("subprocess.run")
+    def test_run_command_basic(self, mock_subprocess_run):
+        """基本的なコマンド実行のテスト"""
+        # Arrange
+        cmd = ["echo", "test"]
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "test\n"
+        mock_result.stderr = ""
+        mock_subprocess_run.return_value = mock_result
+
+        # Act
+        result = run_command(cmd)
+
+        # Assert
+        mock_subprocess_run.assert_called_once_with(cmd, check=True, capture_output=True, text=True)
+        assert result.returncode == 0
+
+    @patch("subprocess.run")
+    def test_run_command_with_verbose(self, mock_subprocess_run):
+        """verboseオプション付きのコマンド実行テスト"""
+        # Arrange
+        cmd = ["echo", "test"]
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "test output"
+        mock_result.stderr = "some stderr"
+        mock_subprocess_run.return_value = mock_result
+
+        # Act
+        result = run_command(cmd, verbose=True)
+
+        # Assert
+        mock_subprocess_run.assert_called_once_with(cmd, check=True, capture_output=True, text=True)
+        assert result.returncode == 0
+
+    @patch("subprocess.run")
+    def test_run_command_with_error(self, mock_subprocess_run):
+        """エラー時のコマンド実行テスト"""
+        # Arrange
+        cmd = ["false"]
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "command failed"
+        mock_subprocess_run.return_value = mock_result
+
+        # Act
+        result = run_command(cmd, check=False, verbose=True)
+
+        # Assert
+        mock_subprocess_run.assert_called_once_with(
+            cmd, check=False, capture_output=True, text=True
+        )
+        assert result.returncode == 1
+
+
+class TestEnsureContainerRunning:
+    """ensure_container_running関数のテスト"""
+
+    @patch("devcontainer_tools.container.is_container_running")
+    def test_container_already_running(self, mock_is_running):
+        """コンテナが既に起動している場合のテスト"""
+        # Arrange
+        workspace = Path("/test/workspace")
+        mock_is_running.return_value = True
+
+        # Act
+        result = ensure_container_running(workspace)
+
+        # Assert
+        assert result is True
+        mock_is_running.assert_called_once_with(workspace)
+
+    @patch("devcontainer_tools.container.run_command")
+    @patch("devcontainer_tools.container.is_container_running")
+    def test_container_start_success(self, mock_is_running, mock_run_command):
+        """コンテナの起動が成功する場合のテスト"""
+        # Arrange
+        workspace = Path("/test/workspace")
+        mock_is_running.return_value = False
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_run_command.return_value = mock_result
+
+        # Act
+        result = ensure_container_running(workspace)
+
+        # Assert
+        assert result is True
+        mock_run_command.assert_called_once_with(
+            ["devcontainer", "up", "--workspace-folder", str(workspace)], check=False, verbose=True
+        )
+
+    @patch("devcontainer_tools.container.run_command")
+    @patch("devcontainer_tools.container.is_container_running")
+    def test_container_start_failure_with_stderr(self, mock_is_running, mock_run_command):
+        """コンテナの起動が失敗する場合のテスト（stderrあり）"""
+        # Arrange
+        workspace = Path("/test/workspace")
+        mock_is_running.return_value = False
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "Docker daemon not running"
+        mock_result.stdout = ""
+        mock_run_command.return_value = mock_result
+
+        # Act
+        result = ensure_container_running(workspace)
+
+        # Assert
+        assert result is False
+
+    @patch("devcontainer_tools.container.run_command")
+    @patch("devcontainer_tools.container.is_container_running")
+    def test_container_start_failure_with_stdout_only(self, mock_is_running, mock_run_command):
+        """コンテナの起動が失敗する場合のテスト（stdoutのみ）"""
+        # Arrange
+        workspace = Path("/test/workspace")
+        mock_is_running.return_value = False
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = ""
+        mock_result.stdout = "Error in stdout"
+        mock_run_command.return_value = mock_result
+
+        # Act
+        result = ensure_container_running(workspace)
+
+        # Assert
+        assert result is False
+
+    @patch("devcontainer_tools.container.run_command")
+    @patch("devcontainer_tools.container.is_container_running")
+    def test_container_start_failure_no_output(self, mock_is_running, mock_run_command):
+        """コンテナの起動が失敗する場合のテスト（出力なし）"""
+        # Arrange
+        workspace = Path("/test/workspace")
+        mock_is_running.return_value = False
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = ""
+        mock_result.stdout = ""
+        mock_run_command.return_value = mock_result
+
+        # Act
+        result = ensure_container_running(workspace)
+
+        # Assert
+        assert result is False
+
+    @patch("devcontainer_tools.container.run_command")
+    @patch("devcontainer_tools.container.is_container_running")
+    def test_container_start_exception(self, mock_is_running, mock_run_command):
+        """コンテナの起動中に例外が発生する場合のテスト"""
+        # Arrange
+        workspace = Path("/test/workspace")
+        mock_is_running.return_value = False
+        mock_run_command.side_effect = Exception("Unexpected error")
+
+        # Act
+        result = ensure_container_running(workspace)
+
+        # Assert
+        assert result is False


### PR DESCRIPTION
## Summary
Issue #32で要求されたDockerエラーハンドリングの改善を実装しました。

- **デバッグ情報の詳細化**: `run_command`関数に`verbose`オプションを追加
- **エラーメッセージの改善**: stderr、stdout、終了コードを順次確認する統一処理
- **包括的なテスト**: 9つの新しいテストケースでエラーシナリオをカバー

## 主な変更点

### 1. run_command関数の拡張
- `verbose=True`で詳細なデバッグ情報を表示
- returncode、stdout、stderrの内容を出力
- 200文字以上の出力は省略表示

### 2. ensure_container_running関数の改善
- devcontainer upの実行結果を詳細に表示
- エラーメッセージの優先順位: stderr → stdout → 終了コード
- 統一されたエラー処理パターン

### 3. stop_and_remove_container関数の改善
- Docker操作のエラーメッセージを詳細化
- 同じエラー処理パターンを適用

## テスト

### 実際に確認したエラーパターン
1. **存在しないDockerイメージ**: 詳細なdevcontainer CLIエラーを表示
2. **設定ファイル不存在**: 適切なエラーメッセージを表示
3. **コンテナ未起動**: ユーザーフレンドリーなメッセージ

### 新規テストケース
- `TestRunCommand`: 3つのテストケース
- `TestEnsureContainerRunning`: 6つのテストケース

## Test plan
- [x] 全テストが合格することを確認
- [x] 実際にエラーシナリオでデバッグ情報が表示されることを確認
- [x] lintとtype-checkが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)