### PR TITLE
improve: dev statusコマンドでdevcontainer未設定時により分かりやすいメッセージを表示

### DIFF
--- a/src/devcontainer_tools/cli.py
+++ b/src/devcontainer_tools/cli.py
@@ -356,7 +356,7 @@ def status(workspace: Path) -> None:
     if config_path:
         table.add_row("Config", str(config_path.relative_to(workspace)))
     else:
-        table.add_row("Config", "Not found")
+        table.add_row("Config", "❌ devcontainerが設定されていません")
 
     console.print(table)
 


### PR DESCRIPTION
## Summary
- devcontainer設定ファイルが見つからない場合に、より分かりやすい日本語メッセージを表示
- 「Not found」→「❌ devcontainerが設定されていません」に変更

## Test plan
- [x] devcontainer設定なしのディレクトリで `dev status` を実行し、改善されたメッセージが表示されることを確認
- [x] devcontainer設定ありのディレクトリで `dev status` を実行し、設定ファイルパスが正常に表示されることを確認
- [x] 全品質チェック（lint、format、type-check、test）が通過することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)